### PR TITLE
Check whether row index is in range before using it

### DIFF
--- a/cell_row_span.py
+++ b/cell_row_span.py
@@ -253,7 +253,7 @@ class CellRowSpanTreeProcessor(Treeprocessor):
             tr_index = 0
             for tr in tbody:
                 # Check for adjacent columns
-                if self.RE_adjacent_bars.search(rows[tr_index+2]):
+                if tr_index + 2 in rows and self.RE_adjacent_bars.search(rows[tr_index+2]):
                     self._update_colspan_attrib(rows[tr_index+2], t_index, tr_index, tr, td_remove)
                 # Check for spanned rows
                 td_index = 0


### PR DESCRIPTION
To avoid the following error:

  File "/home/michal/.local/lib/python3.7/site-packages/markdown/core.py", line 272, in convert                                                                                                                                          
    newRoot = treeprocessor.run(root)                                                                               
  File "/home/michal/.local/lib/python3.7/site-packages/cell_row_span/__init__.py", line 256, in run                
    if self.RE_adjacent_bars.search(rows[tr_index+2]):                                                              
IndexError: list index out of range